### PR TITLE
Remove unused code from `lib/`

### DIFF
--- a/lib/fcom.rb
+++ b/lib/fcom.rb
@@ -3,6 +3,4 @@
 require 'fcom/version'
 
 module Fcom
-  class Error < StandardError; end
-  # Your code goes here...
 end


### PR DESCRIPTION
Ultimately, this whole `lib/fcom.rb` file is probably actually not going to be used for anything. `fcom` is just a command line utility. It's not really meant to be required into a Ruby application (which would be the purpose of `lib/fcom.rb`).