### PR TITLE
Use `slop` gem to parse command argument/options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,9 @@ Style/ClassAndModuleChildren:
     EnforcedStyle: compact
 Style/EmptyCaseCondition:
     Enabled: false
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Breaking changes
+- Change how options should be provided to the `fcom` command
+- Parse command argument/options with `slop` gem
+
 ## 0.1.0 - 2019-12-28
 ### Added
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     fcom (0.1.0)
       colorize (~> 0.8)
+      slop (~> 4.7)
 
 GEM
   remote: https://rubygems.org/
@@ -46,6 +47,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    slop (4.7.0)
     unicode-display_width (1.6.0)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -26,10 +26,20 @@ $ fcom <search string> [number of days to search] [enter "regex" if search strin
 #### Examples
 
 ```
-fcom update
-fcom "def update"
-fcom "def update" 60
-fcom "[Uu]ser.*slug" 365 regex
+$ fcom --help
+
+Usage: fcom <search string> [options]
+
+Examples:
+  fcom update
+  fcom 'def update'
+  fcom "def update" --days 60
+  fcom "[Uu]ser.*slug" -d 365 --regex
+
+    -d, --days        number of days to search back
+    -r, --regex       interpret search string as a regular expression
+    -v, --version     print the version
+    -h, --help        print this help information
 ```
 
 ## Development

--- a/exe/fcom
+++ b/exe/fcom
@@ -2,11 +2,37 @@
 
 # frozen_string_literal: true
 
+require 'slop'
 require_relative '../lib/fcom.rb'
 
-is_parse_mode = (ARGV[3] == 'PARSE_MODE=TRUE')
-if is_parse_mode
-  Fcom::Parser.new(ARGV).parse
+opts = Slop.parse do |o|
+  o.banner = <<~BANNER
+
+    Usage: fcom <search string> [options]
+
+    Examples:
+      fcom update
+      fcom "def update"
+      fcom "def update" --days 60
+      fcom "[Uu]ser.*slug" -d 365 --regex
+  BANNER
+
+  o.integer '-d', '--days', 'number of days to search back'
+  o.bool '-r', '--regex', 'interpret search string as a regular expression', default: false
+  o.bool '-p', '--parse-mode', 'whether we are in parse mode', default: false, help: false
+
+  o.on '-v', '--version', 'print the version' do
+    puts(Fcom::VERSION)
+    exit
+  end
+  o.on '-h', '--help', 'print this help information' do
+    puts(o)
+    exit
+  end
+end
+
+if opts.parse_mode?
+  Fcom::Parser.new(opts).parse
 else
-  Fcom::Querier.new(ARGV).query
+  Fcom::Querier.new(opts).query
 end

--- a/fcom.gemspec
+++ b/fcom.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'colorize', '~> 0.8'
+  spec.add_dependency 'slop', '~> 4.7'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'pry', '~> 0.12'

--- a/lib/fcom/options_helpers.rb
+++ b/lib/fcom/options_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This module contains convenience methods that expose more directly the command options provided.
+module Fcom::OptionsHelpers
+  private
+
+  def days
+    @options[:days]
+  end
+
+  def regex_mode?
+    @options.regex?
+  end
+
+  def search_string
+    @options.arguments.first
+  end
+end

--- a/lib/fcom/parser.rb
+++ b/lib/fcom/parser.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require 'colorize'
+require_relative './options_helpers.rb'
 
 # This class parses (and then reprints some of) STDIN according to the options passed to `fcom`.
 class Fcom::Parser
-  def initialize(argv)
-    @argv = argv
+  include ::Fcom::OptionsHelpers
+
+  def initialize(options)
+    @options = options
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -14,9 +17,8 @@ class Fcom::Parser
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/BlockLength
   def parse
-    use_regex = (@argv[2] == 'regex')
-    expression_to_match = @argv[0]
-    expression_to_match = Regexp.escape(expression_to_match).gsub('\\ ', ' ') unless use_regex
+    expression_to_match = search_string
+    expression_to_match = Regexp.escape(expression_to_match).gsub('\\ ', ' ') unless regex_mode?
     regex = /(\+|\-)\s?.*#{expression_to_match}.*/
 
     previous_commit = nil

--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require_relative './options_helpers.rb'
+
 # This class executes a system command to retrieve the git history, which is passed through `rg`
 # (ripgrep), and then ultimately is fed back to `fcom` for parsing.
 class Fcom::Querier
-  def initialize(argv)
-    @argv = argv
+  include ::Fcom::OptionsHelpers
+
+  def initialize(options)
+    @options = options
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -12,10 +16,8 @@ class Fcom::Querier
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/PerceivedComplexity
   def query
-    days = @argv[1] || -1
-    use_regex = (@argv[2] == 'regex')
-    expression_to_match = @argv[0]
-    expression_to_match = Regexp.escape(expression_to_match).gsub('\\ ', ' ') unless use_regex
+    expression_to_match = search_string
+    expression_to_match = Regexp.escape(expression_to_match).gsub('\\ ', ' ') unless regex_mode?
 
     if expression_to_match.nil? || expression_to_match.size.zero?
       puts('provide expression to match as first argument')
@@ -25,9 +27,9 @@ class Fcom::Querier
     quote = expression_to_match.include?('"') ? "'" : '"'
     # rubocop:disable Style/IfUnlessModifier
     command = <<~COMMAND.tr("\n", ' ')
-      git log #{"--since=#{days}.day" unless days == -1} --full-diff --format="commit %s|%H|%an|%cr (%ci)" --source -p . |
+      git log #{"--since=#{days}.day" unless days.nil?} --full-diff --format="commit %s|%H|%an|%cr (%ci)" --source -p . |
         rg #{quote}(#{expression_to_match})|(^commit )|(^diff )#{quote} --color never |
-        fcom #{quote}#{@argv[0]}#{quote} #{@argv[1] || 10_000} #{@argv[2] || 'dummy_placeholder_for_regex'} PARSE_MODE=TRUE
+        fcom #{quote}#{search_string}#{quote} #{"--days #{days}" if days} #{'--regex' if regex_mode?} --parse-mode
     COMMAND
     # rubocop:enable Style/IfUnlessModifier
     puts("Executing command: #{command}")


### PR DESCRIPTION
I am pretty happy with `slop` and how it has helped me to simplify the code and to improve the user experience (e.g. more-or-less automatically providing a `--help` option).