### PR TITLE
Add `--repo` option to README.md usage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Improved documentation
+
 ## 0.2.1 - 2019-12-28
 ### Added
 - Add `--repo` option, which is used in the GitHub links that are printed for matching commits

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Examples:
   fcom "[Uu]ser.*slug" -d 365 --regex
   fcom "line.(green|red)" -d 365 --regex --repo davidrunger/fcom
 
+    --repo            GitHub repo (in form `username/repo`)
     -d, --days        number of days to search back
     -r, --regex       interpret search string as a regular expression
     -v, --version     print the version

--- a/exe/fcom
+++ b/exe/fcom
@@ -12,14 +12,14 @@ opts = Slop.parse do |o|
 
     Examples:
       fcom update
-      fcom "def update"
+      fcom 'def update'
       fcom "def update" --days 60
       fcom "[Uu]ser.*slug" -d 365 --regex
       fcom "line.(green|red)" -d 365 --regex --repo davidrunger/fcom
   BANNER
 
-  o.integer '-d', '--days', 'number of days to search back'
   o.string '--repo', 'GitHub repo (in form `username/repo`)', default: 'username/repo'
+  o.integer '-d', '--days', 'number of days to search back'
   o.bool '-r', '--regex', 'interpret search string as a regular expression', default: false
   o.bool '-p', '--parse-mode', 'whether we are in parse mode', default: false, help: false
 


### PR DESCRIPTION
Also, list `--repo` option first, because it doesn't have a short option (because `-r` was already being used for `--regex`).

Also, illustrate in the `--help` output that single quotes can be used instead of double quotes.