### PR TITLE
Run Ruby 2.6.5 on Travis (not 2.6.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.3
-before_install: gem install bundler -v 1.17.3
+  - 2.6.5


### PR DESCRIPTION
(Also: remove `before_install` Travis command.)

I'd like to run Ruby 2.7.0, but (at this time) too many deprecation warnings are printed.

The purpose of this PR, as much as anything, was just to trigger/test a Travis build, which apparently just required `travis enable` (since bundler was kind enough to already create a `.travis.yml` file).