### PR TITLE
DRY up slop options definition

### DIFF
--- a/exe/fcom
+++ b/exe/fcom
@@ -5,9 +5,6 @@
 require 'slop'
 require_relative '../lib/fcom.rb'
 
-git_helpers = Fcom::GitHelpers.new
-default_repo = git_helpers.repo || 'username/repo'
-
 opts =
   Slop.parse do |o|
     o.banner = <<~BANNER
@@ -22,10 +19,7 @@ opts =
         fcom "line.(green|red)" -d 365 --regex --repo davidrunger/fcom
     BANNER
 
-    o.string('--repo', 'GitHub repo (in form `username/repo`)', default: default_repo)
-    o.integer('-d', '--days', 'number of days to search back')
-    o.bool('-r', '--regex', 'interpret search string as a regular expression', default: false)
-    o.bool('-p', '--parse-mode', 'whether we are in parse mode', default: false, help: false)
+    Fcom.define_slop_options(o)
 
     o.on('-v', '--version', 'print the version') do
       puts(Fcom::VERSION)

--- a/lib/fcom.rb
+++ b/lib/fcom.rb
@@ -2,6 +2,15 @@
 
 # This `Fcom` module is the namespace within which most of the gem's code is written.
 module Fcom
+  def self.define_slop_options(options)
+    git_helpers = Fcom::GitHelpers.new
+    default_repo = git_helpers.repo || 'username/repo'
+
+    options.string('--repo', 'GitHub repo (in form `username/repo`)', default: default_repo)
+    options.integer('-d', '--days', 'number of days to search back')
+    options.bool('-r', '--regex', 'interpret search string as a regular expression', default: false)
+    options.bool('-p', '--parse-mode', 'whether we are in parse mode', default: false, help: false)
+  end
 end
 
 require_relative './fcom/git_helpers'

--- a/spec/options_helpers_spec.rb
+++ b/spec/options_helpers_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'slop'
-
 RSpec.describe Fcom::OptionsHelpers do
   subject(:options_helper) do
     instance = class_including_options_helpers.new
@@ -13,12 +11,7 @@ RSpec.describe Fcom::OptionsHelpers do
     klass = Class.new
     klass.include(Fcom::OptionsHelpers)
   end
-  let(:options) do
-    options = Slop::Options.new
-    options.integer('-d', '--days')
-    options.bool('-r', '--regex')
-    options.parse(arguments_string.split(/\s+/))
-  end
+  let(:options) { stubbed_slop_options(arguments_string) }
   let(:arguments_string) { 'the_search_target' }
 
   describe '#days' do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Fcom::Parser do
   subject(:parser) { Fcom::Parser.new(options) }
 
-  let(:options) { Slop::Options.new.parse(%w[the_search_string]) }
+  let(:options) { stubbed_slop_options('the_search_string --repo username/reponame') }
 
   before do
     expect(STDIN).to receive(:each) do |_stdin, &blk|
@@ -37,7 +37,7 @@ RSpec.describe Fcom::Parser do
       expect(STDOUT).to receive(:puts).with("\n\n").ordered
       expect(STDOUT).to receive(:puts).with([
         'Add rubocop as a development dependency',
-        '066c52f ( https://github.com//commit/066c52f )',
+        '066c52f ( https://github.com/username/reponame/commit/066c52f )',
         'David Runger',
         '3 days ago (2019-12-28 10:33:45 -0800)',
       ]).ordered

--- a/spec/querier_spec.rb
+++ b/spec/querier_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Fcom::Querier do
   subject(:querier) { Fcom::Querier.new(options) }
 
-  let(:options) { Slop::Options.new.parse(%w[the_search_string]) }
+  let(:options) { stubbed_slop_options('the_search_string') }
 
   describe '#query' do
     subject(:query) { querier.query }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,9 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+def stubbed_slop_options(arguments_string)
+  options = Slop::Options.new
+  Fcom.define_slop_options(options)
+  options.parse(arguments_string.split(/\s+/))
+end


### PR DESCRIPTION
Set up our `slop` CLI options in the same place for both application code and for tests, which will ensure that tests are realistic with respect to the command line options that we make available via `slop`.