### PR TITLE
Remove unnecessary/duplicate `let` from parser_spec.rb

### DIFF
--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -24,15 +24,6 @@ RSpec.describe Fcom::Parser do
       STUBBED_STDIN
     end
 
-    let(:expected_output) do
-      <<~EXPECTED_OUTPUT
-        Add rubocop as a development dependency
-        066c52f ( https://github.com//commit/066c52f )
-        David Runger
-        3 days ago (2019-12-28 10:33:45 -0800)
-      EXPECTED_OUTPUT
-    end
-
     it 'prints stuff' do
       expect(STDOUT).to receive(:puts).with("\n\n").ordered
       expect(STDOUT).to receive(:puts).with([


### PR DESCRIPTION
It was added in 8d4abbf / #14 ; I don't think it was ever used.