### PR TITLE
Add release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Maintenance
+- Added release script
+
 ## 0.2.6 - 2020-06-05
 ### Added
 - Allow searching case-insensitively via `-i`/`--ignore-case` option

--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ the tests. You can also run `bin/console` for an interactive prompt that will al
 experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new
-version, update the version number in `version.rb`, and then run `bundle exec rake release`, which
-will create a git tag for the version, push git commits and tags, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
+version, update the version number in `version.rb`, and then run `bin/release`, which will create a
+git tag for the version and push git commits and tags.
 
 ## Contributing
 

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "master" ]]; then
+  echo "Aborting release! Not on master. Current branch is '$BRANCH'.";
+  exit 1;
+fi
+
+COMMIT_MESSAGE=$(git log --format=%B -n 1)
+if ! [[ $COMMIT_MESSAGE =~ ^Prepare[[:space:]]to[[:space:]]release[[:space:]]v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Aborting release! Commit message is improperly formatted. Commit message is '$COMMIT_MESSAGE'.";
+  exit 1;
+fi
+
+bundle exec rake build release:guard_clean release:source_control_push


### PR DESCRIPTION
This is better than `bundle exec rake release` because (1) it doesn't attempt to push to Rubygems and (2) it verifies that the release is being done from the `master` branch and has a properly formatted commit message.