### PR TITLE
Add version specifications for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Specify dependency versions
+
 ## 0.2.8 - 2020-06-05
 ## Added
 - Add `--debug` option and only print the command(s) being executed if that option is used

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ PATH
   remote: .
   specs:
     fcom (0.2.8)
-      activesupport
-      colorize
-      memoist
-      slop
+      activesupport (~> 6.0)
+      colorize (~> 0.8)
+      memoist (~> 0.16)
+      slop (~> 4.8)
 
 GEM
   remote: https://rubygems.org/

--- a/fcom.gemspec
+++ b/fcom.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('activesupport')
-  spec.add_dependency('colorize')
-  spec.add_dependency('memoist')
-  spec.add_dependency('slop')
+  spec.add_dependency('activesupport', '~> 6.0')
+  spec.add_dependency('colorize', '~> 0.8')
+  spec.add_dependency('memoist', '~> 0.16')
+  spec.add_dependency('slop', '~> 4.8')
 end


### PR DESCRIPTION
Fixes warnings like this that will otherwise occur when executing `gem
specific_install davidrunger/fcom`:
```
WARNING:  open-ended dependency on activesupport (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
```