### PR TITLE
Set `Fcom.logger.level` for both querier and parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Set `Fcom.logger.level` for both querier and parser
+
 ## 0.2.9 - 2020-06-05
 ### Changed
 - Specify dependency versions

--- a/exe/fcom
+++ b/exe/fcom
@@ -32,6 +32,9 @@ opts =
     end
   end
 
+# Note: mutating the globally accessible `Fcom.logger` constant like this is not thread-safe
+Fcom.logger.level = opts.debug? ? Logger::DEBUG : Logger::WARN
+
 if opts.parse_mode?
   Fcom::Parser.new(opts).parse
 else

--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -9,8 +9,6 @@ class Fcom::Querier
 
   def initialize(options)
     @options = options
-    # Note: mutating the globally accessible `Fcom.logger` constant like this is not thread-safe
-    Fcom.logger.level = debug? ? Logger::DEBUG : Logger::WARN
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity


### PR DESCRIPTION
Currently, we only call `Fcom.logger.debug(...)` in the querier, but we should ensure that the appropriate log level is also set to debug or warn for the parser, too, in case we ever call `Fcom.logger.debug(...)` from there, in the future.