### PR TITLE
Stub `Fcom::GitHelpers#repo` in all tests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+### Tests
+- Added logging of how long each example takes to execute
+- Stubbed `Fcom::GitHelpers#repo` in tests to improve spec performance
+
 ## 0.2.10 - 2020-06-05
 ### Changed
 - Set `Fcom.logger.level` for both querier and parser

--- a/spec/git_helpers_spec.rb
+++ b/spec/git_helpers_spec.rb
@@ -6,8 +6,34 @@ RSpec.describe Fcom::GitHelpers do
   describe '#repo' do
     subject(:repo) { git_helper.repo }
 
-    it 'returns a string in form "username/repo" representing the repo' do
-      expect(repo).to eq('davidrunger/fcom')
+    context 'when Fcom::GitHelpers#repo is not stubbed' do
+      before { allow_any_instance_of(Fcom::GitHelpers).to receive(:repo).and_call_original }
+
+      context 'when `git remote ...` indicates that the remote is davidrunger/fcom' do
+        before do
+          expect_any_instance_of(Kernel).
+            to receive(:`).
+            with('git remote show origin').
+            and_return(<<~GIT_REMOTE_OUTPUT)
+              * remote origin
+                Fetch URL: git@github.com:davidrunger/fcom.git
+                Push  URL: git@github.com:davidrunger/fcom.git
+                HEAD branch: master
+                Remote branch:
+                  master tracked
+                Local branches configured for 'git pull':
+                  add-spec-timing merges with remote master
+                  master          merges with remote master
+                  safe            merges with remote master
+                Local ref configured for 'git push':
+                  master pushes to master (up to date)
+            GIT_REMOTE_OUTPUT
+        end
+
+        it 'returns a string in form "username/repo" representing the repo' do
+          expect(repo).to eq('davidrunger/fcom')
+        end
+      end
     end
   end
 end

--- a/spec/querier_spec.rb
+++ b/spec/querier_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Fcom::Querier do
         with(<<~COMMAND.squish)
           git log --full-diff --format="commit %s|%H|%an|%cr (%ci)" --source -p . |
           rg "(the_search_string)|(^commit )|(^diff )" --color never |
-          fcom "the_search_string" --path . --parse-mode --repo davidrunger/fcom
+          fcom "the_search_string" --path . --parse-mode --repo testuser/testrepo
         COMMAND
 
       query

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,9 @@ RSpec.configure do |config|
     # Note: you can also put `@__started = Time.now` anywhere in your spec, to start the timer
     # at a different point
     @__started = Time.now
+
+    # stub this method in all tests because otherwise it calls `git remote ...` which is really slow
+    allow_any_instance_of(Fcom::GitHelpers).to receive(:repo).and_return('testuser/testrepo')
   end
 
   config.after(:each) do |example|


### PR DESCRIPTION
This significantly speeds up tests by avoiding a slow, real call to `git remote ...`.

This change also makes our tests more reliable / consistent across different environments, where the git origin might not always be `davidrunger/fcom`).

# Before

https://travis-ci.org/github/davidrunger/fcom/builds/695213378

```
-----------------------
Spec Performance Report
-----------------------
0.0 secs - Fcom::VERSION is not nil
0.454 secs - Fcom::Parser#parse prints stuff
0.456 secs - Fcom::OptionsHelpers#days when a days option is provided returns that number of days
0.465 secs - Fcom::GitHelpers#repo returns a string in form "username/repo" representing the repo
0.497 secs - Fcom::Querier#query executes a #system call with the expected command
0.511 secs - Fcom::OptionsHelpers#days when a days option was not provided returns nil
```

# After

https://travis-ci.org/github/davidrunger/fcom/builds/695214531

```
-----------------------
Spec Performance Report
-----------------------
0.0 secs - Fcom::VERSION is not nil
0.001 secs - Fcom::OptionsHelpers#days when a days option was not provided returns nil
0.001 secs - Fcom::OptionsHelpers#days when a days option is provided returns that number of days
0.001 secs - Fcom::Querier#query executes a #system call with the expected command
0.001 secs - Fcom::Parser#parse prints stuff
0.005 secs - Fcom::GitHelpers#repo when Fcom::GitHelpers#repo is not stubbed when `git remote ...` indicates that the remote is davidrunger/fcom returns a string in form "username/repo" representing the repo
```

# Conclusion

**Much better!** 😄 