### PR TITLE
Parse options from `.fcom.yml` config file, if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- Add support for an `.fcom.yml` config file (supporting only a `repo` option at this time)
+
 ## 0.2.12 - 2020-06-05
 ### Docs
 - Update the illustrated `--help` output in `README.md` to reflect the `-i`/`--ignore-case` and

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ Examples:
     -h, --help         print this help information
 ```
 
+## `.fcom.yml` config file
+We highly recommend that you create a `.fcom.yml` file in any repository that you plan to search
+with `fcom`. (You might (or might not) want to add `.fcom.yml` to your `~/.gitignore_global` file so
+that this file is not tracked by `git`.)
+
+#### Example `.fcom.yml` config file
+```yaml
+repo: githubusername/reponame
+```
+
+The advantage of creating an `.fcom.yml` config file is that it will make the `fcom` command execute
+more quickly, because time will not be wasted parsing the output of `git remote ...` in order to
+determine the URL of the repo's remote repository (which is used to construct links to matching
+commits).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run

--- a/lib/fcom.rb
+++ b/lib/fcom.rb
@@ -4,6 +4,7 @@ require 'active_support/all'
 require 'colorize'
 require 'memoist'
 require 'slop'
+require 'yaml'
 
 # This `Fcom` class is the namespace within which most of the gem's code is written.
 # We need to define the class before requiring the modules.
@@ -25,9 +26,14 @@ class Fcom
       end
     end
 
+    memoize \
+    def config_file_options
+      Fcom::ConfigFileOptions.new
+    end
+
     def define_slop_options(options)
       git_helpers = Fcom::GitHelpers.new
-      default_repo = git_helpers.repo || 'username/repo'
+      default_repo = config_file_options.repo || git_helpers.repo || 'username/repo'
 
       options.string('--repo', 'GitHub repo (in form `username/repo`)', default: default_repo)
       options.integer('-d', '--days', 'number of days to search back')

--- a/lib/fcom/config_file_options.rb
+++ b/lib/fcom/config_file_options.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Fcom::ConfigFileOptions
+  def initialize
+    config_file_path = "#{ENV['PWD']}/.fcom.yml"
+    @options =
+      if File.exist?(config_file_path)
+        YAML.load_file(config_file_path)
+      else
+        {}
+      end
+  end
+
+  def repo
+    @options['repo']
+  end
+end


### PR DESCRIPTION
Note that not all options can be provided via `.fcom.yml` at this time. Currently only the repo option is supported.