### PR TITLE
Don't print debug statements when executing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Tests
+- Don't print debug statement(s) when executing tests
+
 ## 0.2.15 - 2020-06-05
 ### Fixed
 - Don't print empty spaces before the first matching commit

--- a/exe/fcom
+++ b/exe/fcom
@@ -33,7 +33,7 @@ opts =
   end
 
 # Note: mutating the globally accessible `Fcom.logger` constant like this is not thread-safe
-Fcom.logger.level = opts.debug? ? Logger::DEBUG : Logger::WARN
+Fcom.logger.level = Logger::DEBUG if opts.debug?
 
 if opts.parse_mode?
   Fcom.warn_if_config_file_repo_option_missing

--- a/lib/fcom.rb
+++ b/lib/fcom.rb
@@ -23,6 +23,8 @@ class Fcom
     def logger
       Logger.new(STDOUT).tap do |logger|
         logger.formatter = ->(_severity, _datetime, _progname, msg) { "#{msg}\n" }
+        # default the log level to WARN, but this can be set to `DEBUG` via the `--debug` CLI option
+        logger.level = Logger::WARN
       end
     end
 


### PR DESCRIPTION
The problem is that we were executing

```rb
Fcom.logger.level = opts.debug? ? Logger::DEBUG : Logger::WARN
```

only in `exe/fcom`, which is not executed when we run tests. Thus, in tests, the logger was just having the default log level of `DEBUG`.

This is fixed by setting the logger to `WARN` level by default and overriding to `DEBUG` in `exe/fcom` if the `--debug` CLI option is used.