### PR TITLE
Print warning about missing `.fcom.yml` file before executing querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Fixed
+- Print warning about missing `.fcom.yml` config file before executing querier
+
 ## 0.2.16 - 2020-06-05
 ### Tests
 - Don't print debug statement(s) when executing tests

--- a/exe/fcom
+++ b/exe/fcom
@@ -36,8 +36,8 @@ opts =
 Fcom.logger.level = Logger::DEBUG if opts.debug?
 
 if opts.parse_mode?
-  Fcom.warn_if_config_file_repo_option_missing
   Fcom::Parser.new(opts).parse
 else
+  Fcom.warn_if_config_file_repo_option_missing
   Fcom::Querier.new(opts).query
 end


### PR DESCRIPTION
Prior to this change, when using the `--debug` flag, the command being executed would be printed _before_ the warning about a missing `.fcom.yml` file. This is undesirable; we want the warning to be printed first.