### PR TITLE
Stub `ConfigFileOptions#config_file_exists?` to return false in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Tests
+- Stub `ConfigFileOptions#config_file_exists?` to return `false` in tests
+
 ## 0.2.17 - 2020-06-05
 ### Fixed
 - Print warning about missing `.fcom.yml` config file before executing querier

--- a/lib/fcom/config_file_options.rb
+++ b/lib/fcom/config_file_options.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Fcom::ConfigFileOptions
+  extend Memoist
+
   def initialize
-    config_file_path = "#{ENV['PWD']}/.fcom.yml"
     @options =
-      if File.exist?(config_file_path)
+      if config_file_exists?
         YAML.load_file(config_file_path)
       else
         {}
@@ -13,5 +14,16 @@ class Fcom::ConfigFileOptions
 
   def repo
     @options['repo']
+  end
+
+  private
+
+  memoize \
+  def config_file_path
+    "#{ENV['PWD']}/.fcom.yml"
+  end
+
+  def config_file_exists?
+    File.exist?(config_file_path)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,11 @@ RSpec.configure do |config|
 
     # stub this method in all tests because otherwise it calls `git remote ...` which is really slow
     allow_any_instance_of(Fcom::GitHelpers).to receive(:repo).and_return('testuser/testrepo')
+
+    # pretend that `.fcom.yml` doesn't exist in tests
+    allow_any_instance_of(Fcom::ConfigFileOptions).
+      to receive(:config_file_exists?).
+      and_return(false)
   end
 
   config.after(:each) do |example|


### PR DESCRIPTION
Reasons:
1. probably faster (?), by saving a filesystem read
2. `.fcom.yml` is sort of a git-ignorable file, and as such our tests shouldn't depend on it; it might vary between devs' machines / CI