### PR TITLE
Use `--no-textconv` git option when querying

### DIFF
--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -28,6 +28,7 @@ class Fcom::Querier
       git log
         #{"--since=#{days}.day" unless days.nil?}
         --full-diff
+        --no-textconv
         --format="commit %s|%H|%an|%cr (%ci)"
         --source
         -p #{path}

--- a/spec/fcom/querier_spec.rb
+++ b/spec/fcom/querier_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Fcom::Querier do
       expect_any_instance_of(Kernel).
         to receive(:system).
         with(<<~COMMAND.squish)
-          git log --full-diff --format="commit %s|%H|%an|%cr (%ci)" --source -p . |
+          git log --full-diff --no-textconv --format="commit %s|%H|%an|%cr (%ci)" --source -p . |
           rg "(the_search_string)|(^commit )|(^diff )" --color never |
           fcom "the_search_string" --path . --parse-mode --repo testuser/testrepo
         COMMAND


### PR DESCRIPTION
This will cause git not to use the Rails credentials decrypter, which will speed up querying.