### PR TITLE
Bump BUNDLED WITH bundler version from 2.2.22 to 2.3.23

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,4 +112,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.2.22
+   2.3.23


### PR DESCRIPTION
I think that this will remove the warning mentioned here: https://github.com/rubygems/rubygems/issues/ 5234