### PR TITLE
Change dependabot update time from 03:52 to 04:04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "03:52"
+    time: "04:04"
     timezone: America/Chicago


### PR DESCRIPTION
bc. I think CodeCov runs out of GitHub tokens near the end of the hour