### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,7 +3,7 @@ name: Run Rspec Tests
 on:
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Change primary branch name from `master` to `main`
 
 ## v0.6.0 (2024-02-02)
 - Source Ruby version from `.ruby-version` file

--- a/fcom.gemspec
+++ b/fcom.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
     spec.metadata['homepage_uri'] = spec.homepage
     spec.metadata['source_code_uri'] = 'https://github.com/davidrunger/fcom'
-    spec.metadata['changelog_uri'] = 'https://github.com/davidrunger/fcom/blob/master/CHANGELOG.md'
+    spec.metadata['changelog_uri'] = 'https://github.com/davidrunger/fcom/blob/main/CHANGELOG.md'
   else
     raise('RubyGems 2.0 or newer is required to protect against public gem pushes.')
   end


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.