### PR TITLE
FCOM-1 Don't error if path option is a deleted file

### DIFF
--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -26,13 +26,14 @@ class Fcom::Querier
 
     command = <<~COMMAND.squish
       git log
-        #{%(--author="#{author}") if author}
-        #{"--since=#{days}.day" unless days.nil?}
+        --format="commit %s|%H|%an|%cr (%ci)"
+        --patch
         --full-diff
         --no-textconv
-        --format="commit %s|%H|%an|%cr (%ci)"
-        --source
-        -p #{path}
+        #{%(--author="#{author}") if author}
+        #{"--since=#{days}.day" unless days.nil?}
+        --
+        #{path}
         |
 
       rg #{quote}(#{expression_to_match})|(^commit )|(^diff )#{quote}

--- a/spec/fcom/querier_spec.rb
+++ b/spec/fcom/querier_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Fcom::Querier do
       expect_any_instance_of(Kernel).
         to receive(:system).
         with(<<~COMMAND.squish)
-          git log --full-diff --no-textconv --format="commit %s|%H|%an|%cr (%ci)" --source -p . |
+          git log --format="commit %s|%H|%an|%cr (%ci)" --patch --full-diff --no-textconv -- . |
           rg "(the_search_string)|(^commit )|(^diff )" --color never |
           fcom "the_search_string" --path . --parse-mode --repo testuser/testrepo
         COMMAND
@@ -31,11 +31,11 @@ RSpec.describe Fcom::Querier do
           to receive(:system).
           with(<<~COMMAND.squish)
             git log
-              --author="David Runger"
-              --full-diff
-              --no-textconv
-              --format="commit %s|%H|%an|%cr (%ci)"
-              --source -p . |
+            --format="commit %s|%H|%an|%cr (%ci)"
+            --patch --full-diff --no-textconv
+            --author="David Runger"
+            -- .
+            |
             rg "(the_search_string)|(^commit )|(^diff )" --color never |
             fcom "the_search_string" --path . --parse-mode --repo testuser/testrepo
           COMMAND


### PR DESCRIPTION
I had erroneously thought that `-p` in the git command stands for "path". It actually stands for `--patch`!, and the `-p`/`--patch` option has no relationship to the file path, as I had previously thought.

Therefore, it's no problem to separate out the file path after a ` -- ` separator in the command, which has the advantage of causing the git command not to error if a file has been deleted.