### PR TITLE
Print first 8 characters of commit SHA (not 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Print first 8 characters of commit SHA (not 7)
 
 ## v0.8.0 (2024-06-28)
 - Print a helpful error message if ripgrep is not installed

--- a/lib/fcom/parser.rb
+++ b/lib/fcom/parser.rb
@@ -39,7 +39,8 @@ class Fcom::Parser
       elsif line.match?(regex) && (filename.blank? || path_match?(filename))
         if previous_commit
           title, sha, author, date = previous_commit.split('|')
-          sha_with_url = "#{sha[0, 7]} ( https://github.com/#{repo}/commit/#{sha[0, 7]} )"
+          short_sha = sha[0, 8]
+          sha_with_url = "#{short_sha} ( https://github.com/#{repo}/commit/#{short_sha} )"
 
           puts("\n\n") if a_commit_has_matched # print commit separator, if needed
           puts([title, sha_with_url, author, date])

--- a/spec/fcom/parser_spec.rb
+++ b/spec/fcom/parser_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Fcom::Parser do
     it 'prints stuff' do
       expect($stdout).to receive(:puts).with([
         'Add rubocop as a development dependency',
-        '066c52f ( https://github.com/username/reponame/commit/066c52f )',
+        '066c52f4 ( https://github.com/username/reponame/commit/066c52f4 )',
         'David Runger',
         '3 days ago (2019-12-28 10:33:45 -0800)',
       ]).ordered


### PR DESCRIPTION
Sometimes in a large project I think that I have seen collisions for 7-character SHAs, causing errors/confusion. 8 characters is still pretty brief and makes such collisions 1/16th as likely vs 7 characters. Plus, I prefer even numbers.