### PR TITLE
[gemspec] Enforce only major and minor parts of required Ruby version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+- Enforce only major and minor parts of required Ruby version (loosening the
+  required Ruby version from 3.3.3 to 3.3.0)
 
 ## v0.9.0 (2024-06-28)
 - Print first 8 characters of commit SHA (not 7)

--- a/fcom.gemspec
+++ b/fcom.gemspec
@@ -37,5 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rainbow', '>= 3.0', '< 4')
   spec.add_dependency('slop', '~> 4.8')
 
-  spec.required_ruby_version = ">= #{File.read('.ruby-version').rstrip}"
+  required_ruby_version = File.read('.ruby-version').rstrip.sub(/\A(\d+\.\d+)\.\d+\z/, '\1.0')
+  spec.required_ruby_version = ">= #{required_ruby_version}"
 end


### PR DESCRIPTION
For example, if the `.ruby-version` file has `3.3.3`, then the required Ruby version will be `>= 3.3.0`.

My motivation for making this change is that it seems that this gem requiring Ruby 3.3.3 is causing a problem for dependabot updates: https://github.com/davidrunger/dotfiles/network/updates/848692807

```
Bundler::SolveFailure with message: Could not find compatible versions

Because Ruby >= 3.3.3 could not be found in the local ruby installation
  and fcom >= 0.7.0 depends on Ruby >= 3.3.3,
  fcom >= 0.7.0 cannot be used.
So, because Gemfile depends on fcom >= 0.7.0, <= 0.8.0,
  version solving has failed.
```

I think dependabot might currently use Ruby 3.3.1, so hopefully relaxing from `>= 3.3.3` to `>= 3.3.0` will fix that issue.