### PR TITLE
Default `--rg-options` to `--max-columns=2000` [FCOM-3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Default `--rg-options` to `--max-columns=2000`
 
 ## v0.11.0 (2024-07-16)
 - Search back through renames

--- a/lib/fcom.rb
+++ b/lib/fcom.rb
@@ -75,7 +75,7 @@ class Fcom
       options.string(
         '--rg-options',
         'additional options passed directly to `rg` (e.g. `--rg-options "--max-columns 1000"`)',
-        default: '',
+        default: '--max-columns=2000',
       )
       options.bool('--debug', 'print debugging info', default: false)
       options.bool('--parse-mode', 'whether we are in parse mode', default: false, help: false)

--- a/spec/fcom/querier_spec.rb
+++ b/spec/fcom/querier_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Fcom::Querier do
             with(<<~COMMAND.squish).
               git log --format="commit %s|%H|%an|%cr (%ci)" --patch --full-diff --no-textconv
                 HEAD -- . |
-              rg "(the_search_string)|(^commit )|(^diff )" --color never |
+              rg "(the_search_string)|(^commit )|(^diff )" --color never --max-columns=2000 |
               fcom "the_search_string" --path . --parse-mode --repo testuser/testrepo
             COMMAND
             and_return('')
@@ -52,7 +52,7 @@ RSpec.describe Fcom::Querier do
                 HEAD
                 -- .
                 |
-                rg "(the_search_string)|(^commit )|(^diff )" --color never |
+                rg "(the_search_string)|(^commit )|(^diff )" --color never --max-columns=2000 |
                 fcom "the_search_string" --path . --parse-mode --repo testuser/testrepo
               COMMAND
               and_return('')


### PR DESCRIPTION
I rarely actually have interest in looking at a line that is more than 2,000 characters long. Usually, I think that such a line should never have been committed to the repo, in the first place. So, I think it's pretty rare for me to actually care about such a line. One exception might be an unwrapped line in a markdown file, but hopefully a 2,000 character limit won't eliminate many such lines.