### PR TITLE
Add '--topo-order' (topological order) option to 'git log' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Add `--topo-order` (topological order) option to `git log` command
 
 ## v0.12.1 (2024-08-05)
 - **Performance fix:** only search over renames when a path is given.

--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -33,6 +33,7 @@ class Fcom::Querier
             --format="commit %s|%H|%an|%cr (%ci)"
             --patch
             --full-diff
+            --topo-order
             --no-textconv
             #{%(--author="#{author}") if author}
             #{days_limiter}

--- a/spec/fcom/querier_spec.rb
+++ b/spec/fcom/querier_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Fcom::Querier do
                 --format="commit %s|%H|%an|%cr (%ci)"
                 --patch
                 --full-diff
+                --topo-order
                 --no-textconv
                 --author="David Runger"
                 HEAD


### PR DESCRIPTION
This will order commits as per their order of application to the codebase, rather than the chronological order of the commit dates. These orderings can differ, particularly when it comes to merged branches. I think that generally what we want when they differ is the topological order, rather than the chronological order.