### PR TITLE
[gemspec] Remove upper bounds on versions for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove upper bounds on versions for all dependencies.
 
 ## v0.13.0 (2024-09-08)
 - Add `--topo-order` (topological order) option to `git log` command

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     fcom (0.13.1.alpha)
-      activesupport (>= 6, < 8)
-      memo_wise (>= 1.7, < 2)
-      rainbow (>= 3.0, < 4)
+      activesupport (>= 6)
+      memo_wise (>= 1.7)
+      rainbow (>= 3.0)
       slop (~> 4.8)
 
 GEM

--- a/fcom.gemspec
+++ b/fcom.gemspec
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('activesupport', '>= 6', '< 8')
-  spec.add_dependency('memo_wise', '>= 1.7', '< 2')
-  spec.add_dependency('rainbow', '>= 3.0', '< 4')
+  spec.add_dependency('activesupport', '>= 6')
+  spec.add_dependency('memo_wise', '>= 1.7')
+  spec.add_dependency('rainbow', '>= 3.0')
   spec.add_dependency('slop', '~> 4.8')
 
   required_ruby_version = File.read('.ruby-version').rstrip.sub(/\A(\d+\.\d+)\.\d+\z/, '\1.0')


### PR DESCRIPTION
Let's optimistically assume that all future versions will be compatible. We can add restrictions or roll out a fix if that turns out not to be the case.

The upside of this change is that we don't have to make changes to this gem's gemspec to accommodate newly released versions of its dependencies.