### PR TITLE
Stream results progressively [FCOM-8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Stream results progressively. [#757](https://github.com/davidrunger/fcom/pull/757)
 
 ## v0.14.0 (2024-12-10)
 - Remove upper bounds on versions for all dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-- Stream results progressively. [#757](https://github.com/davidrunger/fcom/pull/757)
+- Stream results progressively. ([#757](https://github.com/davidrunger/fcom/pull/757))
 
 ## v0.14.0 (2024-12-10)
 - Remove upper bounds on versions for all dependencies.

--- a/spec/fcom/querier_spec.rb
+++ b/spec/fcom/querier_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Fcom::Querier do
         context 'when an author option is provided' do
           let(:options) { stubbed_slop_options('the_search_string --author "David Runger"') }
 
-          it 'executes a backticks system call with the expected command' do
-            expect(querier).
-              to receive(:`).
-              with(<<~COMMAND.squish).
+          it 'spawns a pseudoterminal with the expected command' do
+            expect(PTY).
+              to receive(:spawn).
+              with(<<~COMMAND.squish)
                 git log
                 --format="commit %s|%H|%an|%cr (%ci)"
                 --patch
@@ -41,7 +41,6 @@ RSpec.describe Fcom::Querier do
                 rg "(the_search_string)|(^commit )|(^diff )" --color never --max-columns=2000 |
                 fcom "the_search_string" --path . --parse-mode --repo testuser/testrepo
               COMMAND
-              and_return('')
 
             query
           end


### PR DESCRIPTION
This change brings back streaming of results, which I think was broken in #639 .

Unsurprisingly, given the complexity/overhead added to the implementation, the fix herein does hurt performance somewhat, but not terribly. I tested with the following queries in `david_runger` and got:

1. **with latest release:** `time fcom javascript` => 12.9s, 12.7s
1. **with this change:** `time /home/david/code/fcom/exe/fcom javascript` => 15.1s, 14.6s

I think that this is well worthwhile, in order to be able to start seeing streaming results as soon as they begin to become available (which often allows for Ctrl-C to interrupt the command before it finishes, anyway, resulting in a net time savings, even if it is slower if/when run all the way to completion).

Private reference link: https://chat.deepseek.com/a/chat/s/6eb15fc5-626f-48b9-b329-a0fd6933d96a