### PR TITLE
[spec_helper] Require default gems in addition to test gems

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-Bundler.require(:test)
-require_relative '../lib/fcom.rb'
+Bundler.require(:default, :test)
 Dir['spec/support/**/*.rb'].each { |file| require("./#{file}") }
 
 RSpec.configure do |config|


### PR DESCRIPTION
Since our default gems include `gemspec` (and, indeed, consist only of that), we can remove `require_relative '../lib/fcom.rb'`.