### PR TITLE
Use absolute path for parser in '--development' mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Use absolute path for parser in `--development` mode. This makes it possible not only to test queries within the `fcom` repo, but also in other repos.
 
 ## v0.14.2 (2025-02-14)
 - When using `--debug`, print the command used to query for renames and the parsed result.

--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -62,7 +62,7 @@ class Fcom::Querier
             #{@options[:rg_options]}
             |
 
-          #{'exe/' if development?}fcom #{quote}#{search_string}#{quote}
+          #{File.join(__dir__, '../../exe/') if development?}fcom #{quote}#{search_string}#{quote}
             #{"--days #{days}" if days}
             #{'--regex' if regex_mode?}
             #{'--debug' if debug?}


### PR DESCRIPTION
This makes it possible not only to test queries within the `fcom` repo, but also in other repos.