### PR TITLE
Stop printing final extra newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Use absolute path for parser in `--development` mode. This makes it possible not only to test queries within the `fcom` repo, but also in other repos.
+- Stop printing two extra newlines after completion.
 
 ## v0.14.2 (2025-02-14)
 - When using `--debug`, print the command used to query for renames and the parsed result.

--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -78,11 +78,6 @@ class Fcom::Querier
     commands.each do |command|
       Fcom.logger.debug("Executing command: #{command}")
 
-      # Add spacing if needed
-      if previous_command_generated_output
-        print "\n\n"
-      end
-
       PTY.spawn(command) do |stdout, _stdin, _pid|
         any_bytes_seen_for_command = false
 
@@ -92,6 +87,11 @@ class Fcom::Querier
         any_bytes_seen_for_command = true
 
         if first_byte
+          # Add spacing if needed
+          if previous_command_generated_output
+            print "\n\n"
+          end
+
           previous_command_generated_output = true
 
           print(first_byte)


### PR DESCRIPTION
After the overall command was finished, we were printing one or two extra newlines. I actually almost like this, because it separates the `fcom` output from my command prompt, but I don't think we should do it. We must keep our users' terminals relatively clean, and not waste their vertical space.