### PR TITLE
Fix bug where output might not be spaced after following a rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Fix bug where output might not be spaced after following a rename.
 
 ## v0.14.3 (2025-02-14)
 - Use absolute path for parser in `--development` mode. This makes it possible not only to test queries within the `fcom` repo, but also in other repos.

--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -72,38 +72,30 @@ class Fcom::Querier
         COMMAND
       end
 
-    previous_command_generated_output = false
+    a_previous_command_generated_output_not_yet_spaced = false
 
     commands.each do |command|
       Fcom.logger.debug("Executing command: #{command}")
 
       PTY.spawn(command) do |stdout, _stdin, _pid|
-        any_bytes_seen_for_command = false
-
         # Read first byte to detect any output
         first_byte = stdout.read(1)
 
-        any_bytes_seen_for_command = true
-
         if first_byte
           # Add spacing if needed
-          if previous_command_generated_output
+          if a_previous_command_generated_output_not_yet_spaced
             print "\n\n"
           end
 
-          previous_command_generated_output = true
+          a_previous_command_generated_output_not_yet_spaced = true
 
           print(first_byte)
 
           # Now read the rest line by line
           stdout.each_line { puts(it) }
-        else
-          previous_command_generated_output = false
         end
       rescue Errno::EIO
-        if !any_bytes_seen_for_command
-          previous_command_generated_output = false
-        end
+        # The command produced no output.
       end
     end
   end


### PR DESCRIPTION
Test search: `fcom 'mount Blorgh::Engine, :at => "blorgh"' -p guides/source/engines.md` in `rails`.

## Before

No spacing where there should be:

![image](https://github.com/user-attachments/assets/93779e78-b1fc-45cb-93eb-881e3bde11da)

## After

Spacing:

![image](https://github.com/user-attachments/assets/bc437a5f-51a5-4f7c-90a2-0bae682e5a6f)