### PR TITLE
Remove check for alpha version from GitHub Action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,5 @@ jobs:
       run: bin/rubocop --format clang
     - name: Run RSpec tests
       run: bin/rspec --format progress
-    - name: Ensure alpha version
-      run: grep alpha $(find . -type f -name version.rb)
     - name: Ensure no git diff
       run: git diff --exit-code && git diff-index --quiet --cached HEAD


### PR DESCRIPTION
The latest version of `runger_release_assistant` no longer bumps to an alpha version. https://github.com/davidrunger/runger_release_assistant/pull/576