### PR TITLE
Use git '--diff-algorithm=default'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-- Use `--diff-algorithm=default`.
+- Use git `--diff-algorithm=default`.
 
 ## v0.14.4 (2025-02-25)
 - Fix bug where output might not be spaced after following a rename.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Use `--diff-algorithm=default`.
 
 ## v0.14.4 (2025-02-25)
 - Fix bug where output might not be spaced after following a rename.

--- a/lib/fcom/querier.rb
+++ b/lib/fcom/querier.rb
@@ -44,6 +44,7 @@ class Fcom::Querier
             --format="commit %s|%H|%an|%cr (%ci)"
             --patch
             --full-diff
+            --diff-algorithm=default
             --topo-order
             --no-textconv
             --stdin

--- a/spec/fcom/querier_spec.rb
+++ b/spec/fcom/querier_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Fcom::Querier do
                 --format="commit %s|%H|%an|%cr (%ci)"
                 --patch
                 --full-diff
+                --diff-algorithm=default
                 --topo-order
                 --no-textconv
                 --stdin


### PR DESCRIPTION
https://git-scm.com/docs/diff-options#Documentation/diff-options.txt-code--diff-algorithmpatienceminimalhistogrammyerscode

**Motivation:** For one thing, it sounds like the `default` (`myers`) algorithm is probably faster than some of the options (which a user might have configured in their git config), so this might result in a performance improvement.

More importantly, it seems that the other tooling that I use (the VS Code GitLens git blame, GitHub diffs) use the `default` diff algorithm, and so using that diff algorithm produces results that better align with those tools.

As a concrete illustration, in the `david_runger` repo at bc3dd3e9, executing `/home/david/code/fcom/exe/fcom 'moduleResolution' -p tsconfig.json --development` prior to this change would show just one commit, 93729389. However, with this change, that same command will show a later commit, efdc0b36, which (when using the `default` git diff algorithm, but not when using the `histogram` algorithm) appears to have moved that line. When viewing efdc0b36 in GitHub, it shows that the line moved. Also, when putting the cursor on that line in VS Code, GitLens blamed efdc0b36, not 93729389, which, prior to this change, `fcom` would seem to point to.